### PR TITLE
Update regression core

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -27,6 +27,12 @@
   version = "v1.9.0"
 
 [[projects]]
+  name = "github.com/golang/protobuf"
+  packages = ["proto"]
+  revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
+  version = "v1.1.0"
+
+[[projects]]
   branch = "master"
   name = "github.com/google/go-querystring"
   packages = ["query"]
@@ -174,8 +180,20 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["context"]
+  packages = [
+    "context",
+    "context/ctxhttp"
+  ]
   revision = "d11bb6cd8e3c4e60239c9cb20ef68586d74500d0"
+
+[[projects]]
+  branch = "master"
+  name = "golang.org/x/oauth2"
+  packages = [
+    ".",
+    "internal"
+  ]
+  revision = "ec22f46f877b4505e0117eeaab541714644fdd28"
 
 [[projects]]
   branch = "master"
@@ -200,6 +218,20 @@
   version = "v0.3.0"
 
 [[projects]]
+  name = "google.golang.org/appengine"
+  packages = [
+    "internal",
+    "internal/base",
+    "internal/datastore",
+    "internal/log",
+    "internal/remote_api",
+    "internal/urlfetch",
+    "urlfetch"
+  ]
+  revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
+  version = "v1.0.0"
+
+[[projects]]
   name = "gopkg.in/google/go-github.v15"
   packages = ["github"]
   revision = "e48060a28fac52d0f1cb758bc8b87c07bac4a87d"
@@ -216,12 +248,6 @@
   ]
   revision = "df053870ae7070b0350624ba5a22161ba3796cc0"
   version = "v4.1.1"
-
-[[projects]]
-  name = "gopkg.in/src-d/go-errors.v0"
-  packages = ["."]
-  revision = "6f07baca276330431b44ece8ee84ac98167bc4ea"
-  version = "v0.1.0"
 
 [[projects]]
   name = "gopkg.in/src-d/go-errors.v1"
@@ -277,12 +303,6 @@
   version = "v4.3.1"
 
 [[projects]]
-  branch = "master"
-  name = "gopkg.in/src-d/go-log.v0"
-  packages = ["."]
-  revision = "42e9505b7e3741217aac7a8baec2c70359c758dd"
-
-[[projects]]
   name = "gopkg.in/src-d/go-log.v1"
   packages = ["."]
   revision = "2ff6802d241cd249cba62ffca2a5e87ab8f19710"
@@ -292,7 +312,7 @@
   branch = "master"
   name = "gopkg.in/src-d/regression-core.v0"
   packages = ["."]
-  revision = "5f9d0ff8ad936c401fd27e20dc51b68248095c1b"
+  revision = "1fbfb38612ddab963c0066122d855ecb9fa099ed"
 
 [[projects]]
   name = "gopkg.in/warnings.v0"

--- a/cmd/regression/main.go
+++ b/cmd/regression/main.go
@@ -42,7 +42,7 @@ func main() {
 	}
 
 	if config.ShowRepos {
-		repos := regression.NewRepositories(config)
+		repos := regression.NewDefaultRepositories(config)
 		repos.ShowRepos()
 		os.Exit(0)
 	}

--- a/test.go
+++ b/test.go
@@ -19,7 +19,7 @@ type Test struct {
 }
 
 func NewTest(config regression.Config) (*Test, error) {
-	repos := regression.NewRepositories(config)
+	repos := regression.NewDefaultRepositories(config)
 	server := regression.NewGitServer(config)
 
 	return &Test{
@@ -64,7 +64,7 @@ func (t *Test) Run() error {
 			times = 1
 		}
 
-		for _, repo := range t.repos.Names(t.config.Complexity) {
+		for _, repo := range t.repos.Names() {
 			results[version][repo] = make([]*PackResult, times)
 			for i := 0; i < times; i++ {
 				// TODO: do not stop on errors
@@ -96,7 +96,7 @@ func (t *Test) GetResults() bool {
 		a := t.results[versions[i]]
 		b := t.results[versions[i+1]]
 
-		for _, repo := range t.repos.Names(t.config.Complexity) {
+		for _, repo := range t.repos.Names() {
 			fmt.Printf("## Repo %s ##\n", repo)
 
 			// TODO: add more options like discard the first run, do the media, etc
@@ -175,7 +175,7 @@ func (t *Test) prepareServer() error {
 
 func (t *Test) prepareBorges() error {
 	log.Infof("Preparing borges binaries")
-	releases := regression.NewReleases("src-d", "borges")
+	releases := regression.NewReleases("src-d", "borges", t.config.GitHubToken)
 
 	t.borges = make(map[string]*regression.Binary, len(t.config.Versions))
 	for _, version := range t.config.Versions {


### PR DESCRIPTION
Update regression-core for fixes:

* Download all repo references
* Use go-log.v1
* Fix git server execution and stop
* Support GitHub tokens for the API

Needs #4 
Fixes #2 